### PR TITLE
Defered a bug that causes opponent players to have the low hp highlig…

### DIFF
--- a/js/play.js
+++ b/js/play.js
@@ -8,7 +8,7 @@ var play = {
   teamList: [[],[]],
   animateDuration: 2000,
   cardFront: true,
-  fullSyncPeriod: 100,
+  fullSyncPeriod: 10000,
   singleSends: 0,
   btnSize: '',
   percentHeights: [


### PR DESCRIPTION
…ht when above the threshold.

When the app sends a resync, players on full hp get the coloured background that indicates their hp is below the threshold set by the user. I need to test when this bug occurs and then fix it.
For now, I've increased the fullSyncPeriod to 10,000 changes which should reduce how often this problem occurs.