### PR TITLE
Changed position of fullscreen button and added button to display QR

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -12,7 +12,7 @@ var clientMode = 'solo';
 $(document).ready(function() {
   game.queryObj = common.parseQueryString();
   game.gameID = location.pathname.substr(1);
-  displayGameID(game.gameID, game.queryObj);
+  setClientMode(game.gameID, game.queryObj);
   populatePlayerSelect();
   nameRosterButtons();
   hookEvents();
@@ -22,6 +22,10 @@ $(document).ready(function() {
 }); // $( document ).ready(function() {
 
 // Static DOM events
+$( '#show-qr-butt' ).click(function() {
+  displayGameID(game.gameID, game.queryObj);
+});
+
 $( '#roster0-butt' ).click(function() {
   rosterButton(0);
 });
@@ -129,12 +133,10 @@ function populatePlayerSelect() {
   $( '#allPlayers' ).append(captainsHTML + mascotsHTML + playersHTML);
 }
 
-function displayGameID(gameID, queryObj) {
+function setClientMode(gameID, queryObj) {
   if (queryObj.mode && (queryObj.mode[0] == 'host')) {
     clientMode = 'host';
-    joinURL = location.origin + '/' + gameID;
-    $( '#qrcode' ).qrcode(joinURL);
-    console.log( 'Join game url: ' + joinURL);
+    $( '#show-qr-butt' ).removeClass( 'hidden' );
   } else {
     clientMode = 'join';
   }
@@ -144,6 +146,13 @@ function displayGameID(gameID, queryObj) {
   } else {
     $( '#gameIDHolder' ).text(gameID);
   }
+}
+
+function displayGameID(gameID, queryObj) {
+  clientMode = 'host';
+  joinURL = location.origin + '/' + gameID;
+  $( '#qrcode' ).qrcode(joinURL);
+  $( '#show-qr-butt' ).addClass( 'hidden' );
 }
 
 // Generated DOM events

--- a/pages/game.html
+++ b/pages/game.html
@@ -24,8 +24,11 @@
         <div class="hidden-xs col-sm-1 col-md-2 col-lg-3"></div>
         <div class="col-xs-12 col-sm-10 col-md-8 col-lg-6">
           <h5 id="output" class="text-center"></h5>
+          <p>
+            <button id="show-qr-butt" class="btn btn-default btn-lg btn-block hidden" type="button">Show QR Code</button>
+          </p>
           <div id="qrcode" class="text-center"></div>
-          <h3 id="gameIDTitle" class="text-center">Game ID: <span id="gameIDHolder"></span></h3>
+          <h2 id="gameIDTitle" class="text-center">Game ID: <span id="gameIDHolder"></span></h2>
           <div id="rosterSelect">
             <p>Choose a Roster:</p>
             <p>

--- a/pages/play.html
+++ b/pages/play.html
@@ -115,18 +115,18 @@
                   </button>
                 </span>
               </div>
-              <div id="makeFullscreen-div" class="small-margin-top hidden">
-                <button id="makeFullscreen" class="btn btn-default btn-block" type="button">Fullscreen</button>
-              </div>
             </div>
           </div>
           <div id="cardCol" class="hidden-xs col-sm-6 col-md-6 col-lg-4">
-            <div id="cardPanel" class="hidden">
+            <div id="makeFullscreen-div" class="small-margin-top hidden">
+              <button id="makeFullscreen" class="btn btn-default btn-block" type="button">Fullscreen</button>
+            </div>
+            <div id="cardPanel">
               <a id="playerCard" href="#"></a>
             </div>
           </div>
           <div id="cardCol2" class="visible-lg-inline col-lg-4">
-            <div id="cardPanel2" class="hidden">
+            <div id="cardPanel2">
               <div id="playerCard2"></div>
             </div>
           </div>


### PR DESCRIPTION
code.

Move the fullscreen button on the play page to be above the player
cards. This means phone sized devices won't have the option to display
fullscreen unless they set their fullscreen option to "player buttons".

QR codes were taking up too much room on phone displays and most people
don't have QR code readers anyway so now they don't display
automatically. Instead there is now a button to display the QR code.