### PR TITLE
Made it easier to set up overlays and fixed analytics

### DIFF
--- a/index.js
+++ b/index.js
@@ -281,7 +281,9 @@ client.updateMaxGames = function updateMaxGames(currentGames, callback) {
 client.on( 'ready', function() {
   console.log( 'Connected to Redis server' );
   createDemos(this);
-  this.updateMaxGames(analytics.currentGames);
+  this.updateMaxGames(analytics.currentGames, function(newMax) {
+    analytics.maxGames = newMax;
+  });
 });
 
 // Demos

--- a/js/spec.js
+++ b/js/spec.js
@@ -153,7 +153,8 @@ function windowResized() {
   var w0 = $( '#default-0' ).width();
   var w1 = $( '#default-1' ).width();
   $( '#element-dimensions' ).html( 'w' + w0 + ', h' + h0 +
-    ' / w' + w1 + ', h' + h1);
+    ' / w' + w1 + ', h' + h1 + '<br>' +
+    'Difference in height: ' + Math.abs(h0-h1));
   var ww = $(window).width();
   var hw = $(window).height();
   $( '#window-dimensions' ).html( 'Window: w' + ww + ', h' + hw);
@@ -190,6 +191,7 @@ socket.on( 'broadcastRosters', function(teamArr) {
     updatePlayersHP(sides[i].players, i);
     updateVPs(sides[i], i)
   }
+  windowResized()
 });
 
 socket.on( 'onePlayerToClient', function(playerObj, currentPlayer, mode) {

--- a/pages/spec.html
+++ b/pages/spec.html
@@ -26,7 +26,6 @@
         <div class="col-xs-6 text-center">
           <div id="window-dimensions"></div>
           <div id="element-dimensions"></div>
-          <div>Alchemists &ndash; 18 shouldn't wrap.</div>
         </div>
       </div>
       <div class="row">


### PR DESCRIPTION
Spectator page now shows the difference in height between the left and right team displays so you can resize your screen regions more easily when making a stream overlay.

Fixed not reading previous maximum concurrent games when first connecting to the database.